### PR TITLE
Added Blank interfaces to disable each component of the manipulator for testing

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -70,7 +70,7 @@ public class RobotContainer {
                 new ModuleIOSpark(1),
                 new ModuleIOSpark(2),
                 new ModuleIOSpark(3));
-        manipulator=new Manipulator();
+        manipulator = new Manipulator();
         vision =
             new Vision(
                 drive::addVisionMeasurement, new VisionIOLimelight("camera1", drive::getRotation));
@@ -85,7 +85,7 @@ public class RobotContainer {
                 new ModuleIOSim(),
                 new ModuleIOSim(),
                 new ModuleIOSim());
-        manipulator=new Manipulator();
+        manipulator = new Manipulator();
         vision =
             new Vision(
                 drive::addVisionMeasurement,
@@ -103,7 +103,7 @@ public class RobotContainer {
                 new ModuleIO() {},
                 new ModuleIO() {},
                 new ModuleIO() {});
-        manipulator=new Manipulator();
+        manipulator = new Manipulator();
         vision = new Vision(drive::addVisionMeasurement, new VisionIO() {});
 
         break;
@@ -139,7 +139,7 @@ public class RobotContainer {
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
   private void configureButtonBindings() {
-    //Default Commands, normal field-relative drive
+    // Default Commands, normal field-relative drive
     drive.setDefaultCommand(
         DriveCommands.joystickDrive(
             drive,
@@ -179,37 +179,21 @@ public class RobotContainer {
 
     xBoxController
         .povUp()
-        .onTrue(Commands.runOnce(
-            () ->
-                manipulator.incrementLevel(),
-                manipulator));
+        .onTrue(Commands.runOnce(() -> manipulator.incrementLevel(), manipulator));
     xBoxController
         .povDown()
-        .onTrue(Commands.runOnce(
-            () ->
-                manipulator.decrementLevel(),
-                manipulator));
-    xBoxController
-        .leftBumper()
-        .onTrue(Commands.runOnce(
-            () ->
-                manipulator.intake(),
-                manipulator));
-    xBoxController
-        .rightBumper()
-        .onTrue(Commands.runOnce(
-            () ->
-                manipulator.expel(),
-                manipulator));
+        .onTrue(Commands.runOnce(() -> manipulator.decrementLevel(), manipulator));
+    xBoxController.leftBumper().onTrue(Commands.runOnce(() -> manipulator.intake(), manipulator));
+    xBoxController.rightBumper().onTrue(Commands.runOnce(() -> manipulator.expel(), manipulator));
     xBoxController
         .leftStick()
-        .onTrue(Commands.run(
-            () ->
-                {
-                    if(xBoxController.rightStick().getAsBoolean()){
-                        manipulator.emergencyStop();
-                    }
-                } ,
+        .onTrue(
+            Commands.run(
+                () -> {
+                  if (xBoxController.rightStick().getAsBoolean()) {
+                    manipulator.emergencyStop();
+                  }
+                },
                 manipulator));
   }
 

--- a/src/main/java/frc/robot/subsystems/manipulator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/Elevator.java
@@ -15,7 +15,7 @@ import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkFlexConfig;
 import edu.wpi.first.wpilibj.DigitalInput;
 
-public class Elevator {
+public class Elevator implements ElevatorInterface {
 
   // creating all the constants
 
@@ -65,28 +65,6 @@ public class Elevator {
   private final SparkClosedLoopController m_PIDController = m_leftMotor.getClosedLoopController();
 
   private final double maxElevatorSpeed = 1.0; // meters per second
-
-  // create an enum for preset elevator heights (ex. coral level 1, 2, 3, 4)
-  public static enum ElevatorPosition {
-    coralL1(100),
-    coralL2(200),
-    coralL3(300),
-    coralL4(400),
-    algaeL1(250),
-    algaeL2(350),
-    coralIntake(250),
-    algaeBarge(500),
-    algaeProcessor(50),
-    algaeIntake(25),
-    bottom(0),
-    top(500);
-
-    public final double position;
-
-    ElevatorPosition(double position) {
-      this.position = position;
-    }
-  }
 
   public Elevator() {
 

--- a/src/main/java/frc/robot/subsystems/manipulator/ElevatorBlank.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/ElevatorBlank.java
@@ -1,0 +1,26 @@
+package frc.robot.subsystems.manipulator;
+
+public class ElevatorBlank implements ElevatorInterface {
+
+  // returns the state of the limit switch
+  public boolean getLimit(){
+    return false;
+  }
+
+  // moves the elevator to a preset position specified by the Position parameter (created in the
+  // enum)
+  public void setPosition(ElevatorPosition position){
+  }
+
+  public void setSpeed(double joystickInput){
+  }
+
+  // moves the elevator a certain speed according to the double parameter
+  public void move(){
+
+  }
+
+  public double getHeight(){
+    return 0;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/manipulator/ElevatorBlank.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/ElevatorBlank.java
@@ -3,24 +3,20 @@ package frc.robot.subsystems.manipulator;
 public class ElevatorBlank implements ElevatorInterface {
 
   // returns the state of the limit switch
-  public boolean getLimit(){
+  public boolean getLimit() {
     return false;
   }
 
   // moves the elevator to a preset position specified by the Position parameter (created in the
   // enum)
-  public void setPosition(ElevatorPosition position){
-  }
+  public void setPosition(ElevatorPosition position) {}
 
-  public void setSpeed(double joystickInput){
-  }
+  public void setSpeed(double joystickInput) {}
 
   // moves the elevator a certain speed according to the double parameter
-  public void move(){
+  public void move() {}
 
-  }
-
-  public double getHeight(){
+  public double getHeight() {
     return 0;
   }
 }

--- a/src/main/java/frc/robot/subsystems/manipulator/ElevatorInterface.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/ElevatorInterface.java
@@ -1,0 +1,39 @@
+package frc.robot.subsystems.manipulator;
+
+public interface ElevatorInterface {
+  // create an enum for preset elevator heights (ex. coral level 1, 2, 3, 4)
+  public enum ElevatorPosition {
+    coralL1(100),
+    coralL2(200),
+    coralL3(300),
+    coralL4(400),
+    algaeL1(250),
+    algaeL2(350),
+    coralIntake(250),
+    algaeBarge(500),
+    algaeProcessor(50),
+    algaeIntake(25),
+    bottom(0),
+    top(500);
+
+    public final double position;
+
+    ElevatorPosition(double position) {
+      this.position = position;
+    }
+  }
+
+  // returns the state of the limit switch
+  public boolean getLimit();
+
+  // moves the elevator to a preset position specified by the Position parameter (created in the
+  // enum)
+  public void setPosition(ElevatorPosition position);
+
+  public void setSpeed(double joystickInput);
+
+  // moves the elevator a certain speed according to the double parameter
+  public void move();
+
+  public double getHeight();
+}

--- a/src/main/java/frc/robot/subsystems/manipulator/Hand.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/Hand.java
@@ -11,7 +11,7 @@ import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
 import com.revrobotics.spark.config.SparkMaxConfig;
 import edu.wpi.first.wpilibj.DigitalInput;
 
-public class Hand {
+public class Hand implements HandInterface {
 
   private final int leftMotorCANID = 13;
   private final int rightMotorCANID = 14;

--- a/src/main/java/frc/robot/subsystems/manipulator/HandBlank.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/HandBlank.java
@@ -1,36 +1,28 @@
 package frc.robot.subsystems.manipulator;
 
-public class HandBlank {
+public class HandBlank implements HandInterface {
 
-  public void intakeCoral(){
-  }
+  public void intakeCoral() {}
 
-  public void clockwise(){
-  }
+  public void clockwise() {}
 
-  public void counterClockwise(){
-  }
+  public void counterClockwise() {}
 
-  public void expelCoral(){
-  }
+  public void expelCoral() {}
 
-  public void stopMotors(){
-  }
+  public void stopMotors() {}
 
-  public boolean coralInPosition(){
+  public boolean coralInPosition() {
     return false;
   }
 
-  public void intakeAlgae(){
-  }
+  public void intakeAlgae() {}
 
-  public void expelAlgaeNet(){
-  }
+  public void expelAlgaeNet() {}
 
-  public void expelAlgaeProcessor(){
-  }
+  public void expelAlgaeProcessor() {}
 
-  public boolean algaeInPosition(){
+  public boolean algaeInPosition() {
     return false;
   }
 }

--- a/src/main/java/frc/robot/subsystems/manipulator/HandBlank.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/HandBlank.java
@@ -1,0 +1,36 @@
+package frc.robot.subsystems.manipulator;
+
+public class HandBlank {
+
+  public void intakeCoral(){
+  }
+
+  public void clockwise(){
+  }
+
+  public void counterClockwise(){
+  }
+
+  public void expelCoral(){
+  }
+
+  public void stopMotors(){
+  }
+
+  public boolean coralInPosition(){
+    return false;
+  }
+
+  public void intakeAlgae(){
+  }
+
+  public void expelAlgaeNet(){
+  }
+
+  public void expelAlgaeProcessor(){
+  }
+
+  public boolean algaeInPosition(){
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/manipulator/HandInterface.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/HandInterface.java
@@ -1,0 +1,24 @@
+package frc.robot.subsystems.manipulator;
+
+public interface HandInterface {
+
+  public void intakeCoral();
+
+  public void clockwise();
+
+  public void counterClockwise();
+
+  public void expelCoral();
+
+  public void stopMotors();
+
+  public boolean coralInPosition();
+
+  public void intakeAlgae();
+
+  public void expelAlgaeNet();
+
+  public void expelAlgaeProcessor();
+
+  public boolean algaeInPosition();
+}

--- a/src/main/java/frc/robot/subsystems/manipulator/Manipulator.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/Manipulator.java
@@ -7,7 +7,7 @@ import frc.robot.subsystems.manipulator.WristInterface.WristAngle;
 public class Manipulator extends SubsystemBase {
   // Set to "Blank" versions to disable each component
   private final HandInterface robotHand = new Hand();
-  private final Wrist robotWrist = new Wrist();
+  private final WristInterface robotWrist = new Wrist();
   private final ElevatorInterface robotElevator = new Elevator();
   private final double elevatorHeightTolerance = 0.01;
 

--- a/src/main/java/frc/robot/subsystems/manipulator/Manipulator.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/Manipulator.java
@@ -1,13 +1,14 @@
 package frc.robot.subsystems.manipulator;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.subsystems.manipulator.Elevator.ElevatorPosition;
-import frc.robot.subsystems.manipulator.Wrist.WristAngle;
+import frc.robot.subsystems.manipulator.ElevatorInterface.ElevatorPosition;
+import frc.robot.subsystems.manipulator.WristInterface.WristAngle;
 
 public class Manipulator extends SubsystemBase {
-  private final Hand robotHand = new Hand();
+  // Set to "Blank" versions to disable each component
+  private final HandInterface robotHand = new Hand();
   private final Wrist robotWrist = new Wrist();
-  private final Elevator robotElevator = new Elevator();
+  private final ElevatorInterface robotElevator = new Elevator();
   private final double elevatorHeightTolerance = 0.01;
 
   private final ElevatorPosition[] elevatorPositions = {

--- a/src/main/java/frc/robot/subsystems/manipulator/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/Wrist.java
@@ -16,7 +16,7 @@ import com.revrobotics.spark.config.SparkFlexConfig;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.DigitalInput;
 
-public class Wrist {
+public class Wrist implements WristInterface {
 
   // encoder - TBD gear ratio - TBD
 
@@ -44,26 +44,6 @@ public class Wrist {
   private final int wristMotorCANID = 314159; // TODO: fix the can ids
   private final int wristLimitSwitchCANID = 271817181;
   private final double maxWristSpeed = 90; // degrees per second
-
-  // create an enum for preset elevator heights (ex. coral level 1, 2, 3, 4)
-  public static enum WristAngle {
-    coralBottom(-1),
-    coralMiddle(-1),
-    coralTop(-1),
-    coralIntake(-1),
-    algaeInReef(-1),
-    algaeBarge(-1),
-    algaeProcessor(-1),
-    algaeIntake(-1),
-    bottom(-1),
-    top(-1);
-
-    public final double angle;
-
-    WristAngle(double angle) {
-      this.angle = angle;
-    }
-  }
 
   public Wrist() {
     wristMotor = new SparkMax(wristMotorCANID, MotorType.kBrushless);

--- a/src/main/java/frc/robot/subsystems/manipulator/WristBlank.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/WristBlank.java
@@ -1,0 +1,24 @@
+package frc.robot.subsystems.manipulator;
+
+public class WristBlank implements WristInterface {
+
+  public void resetEncoder(double angle){
+  }
+
+  public double getPosition(){
+    return 0;
+  }
+
+  public boolean getLimitSwitch(){
+    return false;
+  }
+
+  public void setWristSpeed(double joystickInput){
+  }
+
+  public void setWristAngle(WristAngle angle){
+  }
+
+  public void updateWrist(){
+  }
+}

--- a/src/main/java/frc/robot/subsystems/manipulator/WristBlank.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/WristBlank.java
@@ -2,23 +2,19 @@ package frc.robot.subsystems.manipulator;
 
 public class WristBlank implements WristInterface {
 
-  public void resetEncoder(double angle){
-  }
+  public void resetEncoder(double angle) {}
 
-  public double getPosition(){
+  public double getPosition() {
     return 0;
   }
 
-  public boolean getLimitSwitch(){
+  public boolean getLimitSwitch() {
     return false;
   }
 
-  public void setWristSpeed(double joystickInput){
-  }
+  public void setWristSpeed(double joystickInput) {}
 
-  public void setWristAngle(WristAngle angle){
-  }
+  public void setWristAngle(WristAngle angle) {}
 
-  public void updateWrist(){
-  }
+  public void updateWrist() {}
 }

--- a/src/main/java/frc/robot/subsystems/manipulator/WristInterface.java
+++ b/src/main/java/frc/robot/subsystems/manipulator/WristInterface.java
@@ -1,0 +1,36 @@
+package frc.robot.subsystems.manipulator;
+
+public interface WristInterface {
+
+  // create an enum for preset elevator heights (ex. coral level 1, 2, 3, 4)
+  public enum WristAngle {
+    coralBottom(-1),
+    coralMiddle(-1),
+    coralTop(-1),
+    coralIntake(-1),
+    algaeInReef(-1),
+    algaeBarge(-1),
+    algaeProcessor(-1),
+    algaeIntake(-1),
+    bottom(-1),
+    top(-1);
+
+    public final double angle;
+
+    WristAngle(double angle) {
+      this.angle = angle;
+    }
+  }
+
+  public void resetEncoder(double angle);
+
+  public double getPosition();
+
+  public boolean getLimitSwitch();
+
+  public void setWristSpeed(double joystickInput);
+
+  public void setWristAngle(WristAngle angle);
+
+  public void updateWrist();
+}


### PR DESCRIPTION
Made interfaces for each component of the manipulator. With this we can use polymorphism in the manipulator to switch between the actual component classes and "Blank" versions that have functionality disabled. This will allow us to test each component individual as hardware team complete them without running into runtime errors where addition motor controllers are expected, but not present.

@davidsch22 Please review to make sure this looks right. If it does, squash merge into manipulator branch. Once merged, please delete nullInterfaces branch. I believe Elevator and Wrist branches can be deleted as well. Hand branch is still being used for LED development.